### PR TITLE
ADD drag handles + MINOR refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+lib/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 lib/
+example/dist
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "react-dom": ">=0.14.5"
   },
   "devDependencies": {
-    "babel": "^6.1.18",
     "babel-cli": "^6.2.0",
+    "babel-core": "^6.7.2",
     "babel-eslint": "^5.0.0",
+    "babel-loader": "^6.2.4",
     "babel-plugin-espower": "2.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.1.18",
@@ -78,7 +79,6 @@
   ],
   "dependencies": {
     "lodash.isequal": "^4.1.1",
-    "react-motion": "^0.3.1",
-    "react-resizable-box": "^0.2.0"
+    "react-motion": "^0.3.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,10 @@ class SortablePane extends Component {
     this.setSize();
   }
 
-  componentWillUpdate(next) {
+  componentWillUpdate(nextProps) {
     const { panes } = this.state;
-    if (next.children.length > panes.length) return this.addPane(next);
-    if (next.children.length < panes.length) return this.removePane(next);
+    if (nextProps.children.length > panes.length) return this.addPane(nextProps);
+    if (nextProps.children.length < panes.length) return this.removePane(nextProps);
     return null;
   }
 
@@ -181,9 +181,11 @@ class SortablePane extends Component {
     });
   }
 
-  addPane(next) {
+  addPane(nextProps) {
+    console.log(nextProps)
     let newPanes = this.state.panes;
-    next.children.forEach((child, i) => {
+    nextProps.children.forEach((child, i) => {
+      console.log(child, i)
       const ids = this.state.panes.map(pane => pane.id);
       if (ids.indexOf(child.props.id) === -1) {
         newPanes = this.updateOrder(newPanes, i, 'add');
@@ -196,10 +198,10 @@ class SortablePane extends Component {
     this.hasAdded = true;
   }
 
-  removePane(next) {
+  removePane(nextProps) {
     let newPanes;
     this.state.panes.forEach((pane, i) => {
-      const ids = next.children.map(child => child.props.id);
+      const ids = nextProps.children.map(child => child.props.id);
       if (ids.indexOf(pane.id) === -1) {
         newPanes = this.updateOrder(this.state.panes, i, 'remove');
         newPanes.splice(i, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,11 @@ class SortablePane extends Component {
     onOrderChange: PropTypes.func,
     className: PropTypes.string,
     isResizable: PropTypes.shape({
-      x: React.PropTypes.bool,
-      y: React.PropTypes.bool,
-      xy: React.PropTypes.bool,
+      x: PropTypes.bool,
+      y: PropTypes.bool,
+      xy: PropTypes.bool,
     }),
+    dragHandleClass: PropTypes.string
   };
 
   static defaultProps = {
@@ -52,6 +53,7 @@ class SortablePane extends Component {
       y: true,
       xy: true,
     },
+    dragHandleClass: undefined
   };
 
   constructor(props) {
@@ -219,7 +221,10 @@ class SortablePane extends Component {
     this.props.onResizeStop({ id: panes[order.indexOf(i)].id, dir, size, rect });
   }
 
-  handleMouseDown(pos, pressX, pressY, { pageX, pageY }) {
+handleMouseDown(pos, pressX, pressY, { target, pageX, pageY }) { //NOTE: destructures pageX, pageY from React's `SyntheticMouseEvent`
+    if (!!this.props.dragHandleClass && !target.classList.contains(this.props.dragHandleClass))
+      return;
+
     this.setState({
       delta: this.isHorizontal() ? pageX - pressX : pageY - pressY,
       mouse: this.isHorizontal() ? pressX : pressY,
@@ -263,7 +268,7 @@ class SortablePane extends Component {
       const springPosition = spring(this.getItemPositionByIndex(order.indexOf(i)), springConfig);
       const style = lastPressed === i && isPressed
               ? {
-                scale: disableEffect ? 1 : spring(1.05, springConfig),
+                scale: disableEffect ? 1 : spring(0.95, springConfig),
                 shadow: disableEffect ? 0 : spring(16, springConfig),
                 x: this.isHorizontal() ? mouse : 0,
                 y: !this.isHorizontal() ? mouse : 0,
@@ -302,7 +307,10 @@ class SortablePane extends Component {
                   zIndex: i === lastPressed ? 99 : i, // TODO: Add this.props.zIndex
                   position: 'absolute',
                 })}
-                onMouseDown={onMouseDown}
+                onMouseDown={
+                  onMouseDown
+                  // (...args) => console.log(...args)
+                }
                 onTouchStart={onTouchStart}
                 onResizeStart={onResizeStart}
                 onResizeStop={onResizeStop}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { Motion, spring } from 'react-motion';
-import Resizable from 'react-resizable-box';
+import Resizable from '/lib/react-resizable-box/src/index.js';
 import isEqual from 'lodash.isequal';
 import Pane from './pane';
 

--- a/src/pane.js
+++ b/src/pane.js
@@ -28,4 +28,3 @@ export default class Pane extends Component {
     );
   }
 }
-


### PR DESCRIPTION
@bokuweb GREAT WORK SO FAR!!!  :+1: 
here are some minor improvements, hope you're willing to pull them after reviewing ;)

ADD prop `draggableHandleClass` and change `onMouseDown` handler to drag (sort) panes only when dragging target has specific className :)
[MINOR] REFACTOR `next` -> `nextProps`
[MINOR] ADD .gitignore
