### PR TITLE
Sort trigger position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-pane",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Previously, the panes would be reordered only when the top of the
dragged pane crossed the top of another pane.  (Or left passed left.)

With this change, a pane will be reordered when its top crosses halfway
over the previous pane when being dragged up/left, or when the bottom
passes halfway over the pane below/right.  This is much more symmetrical
and feels more natural.

Before:
![sortable-pane-before](https://cloud.githubusercontent.com/assets/4616705/15191042/d2f1352c-1780-11e6-99f6-2ab7ec6a3d53.gif)

After:
![sortable-pane-vert-halfway](https://cloud.githubusercontent.com/assets/4616705/15190762/a17f50b0-177f-11e6-9fc6-97285f960e70.gif)

After with effect:
![sortable-pane-vert-halfway-effect](https://cloud.githubusercontent.com/assets/4616705/15190880/2a2865b4-1780-11e6-9672-69844335d9ca.gif)

After horizontal:
![sortable-pane-horiz-halfway-effect](https://cloud.githubusercontent.com/assets/4616705/15190863/1d638962-1780-11e6-9302-58dc1c2c6001.gif)

Also, the version in package.json didn't match the latest npm version, so I updated that as well.
