### PR TITLE
Allow strings for width & height props

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,15 @@ For example, when `<Resizable width={100} height={200} style={{ padding: '20px'}
 
 The `id` property is used to Pane component id.
 
-#### `width`: PropTypes.number
+#### `width`: oneOfType([PropTypes.number, PropTypes.string])
 
 The `width` property is used to set the width of a Pane component.
+For example, it can be 300, '300px', or 50%.
 
-#### `height`: PropTypes.number
+#### `height`: oneOfType([PropTypes.number, PropTypes.string])
 
 The `height` property is used to set the width of a Pane component.
+For example, it can be 300, '300px', or 50%.
 
 #### `minWidth`: PropTypes.number
 

--- a/src/pane.js
+++ b/src/pane.js
@@ -3,11 +3,17 @@ import React, { Component, PropTypes } from 'react';
 export default class Pane extends Component {
   static propTypes = {
     id: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
+      PropTypes.string,
+      PropTypes.number,
     ]).isRequired,
-    width: PropTypes.number,
-    height: PropTypes.number,
+    width: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+    height: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
     minWidth: PropTypes.number,
     maxWidth: PropTypes.number,
     minHeight: PropTypes.number,
@@ -28,4 +34,3 @@ export default class Pane extends Component {
     );
   }
 }
-


### PR DESCRIPTION
It is possible to pass a percentage for height and width, but the propTypes of this repo were not updated to accept a string.
