### PR TITLE
Fix remove after order change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,7 @@ class SortablePane extends Component {
     this.state.panes.forEach((pane, i) => {
       const ids = this.props.children.map(child => child.props.id);
       if (ids.indexOf(pane.id) === -1) {
-        newPanes = this.updateOrder(this.state.panes, i, 'remove');
+        newPanes = this.updateOrder(this.state.panes, pane.order, 'remove');
         newPanes.splice(i, 1);
       }
     });


### PR DESCRIPTION
This fixes the following bug:
1. Create a SortablePane with two components
2. Drag the panes to swap their order
3. Remove the now-first pane (originally the second pane before
   dragging)
4. Try dragging the remaining pane. Note that it doesn't work and
   there are a bunch of errors in the browser's dev console

The fix updates the order attribute of the other panes based on
the removed pane's order attribute, not its index in the pane list.