### PR TITLE
Add grid prop to SortablePane

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ If omitted the default margin is `0`.
 The `zIndex` property is used to set the zIndex of a component.
 If omitted the default margin is `100`.
 
+#### `grid?: Array<number>;`
+
+The `grid` property is used to specify the increments that resizing should snap to. Defaults to `[1, 1]`.
+
 #### `isSortable?: boolean`
 
 The `isSortable` property is used to control whether panes can be dragged or not.

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -99,6 +99,7 @@ export type SortablePaneProps = $Exact<{
   isSortable?: boolean;
   zIndex?: number;
   dragHandleClassName?: string;
+  grid?: [number, number];
 }>
 
 class SortablePane extends React.Component {
@@ -587,6 +588,7 @@ class SortablePane extends React.Component {
                 onResizeStart={onResizeStart}
                 onResizeStop={onResizeStop}
                 extendsProps={extendsProps}
+                grid={this.props.grid}
               >
                 {child.props.children}
               </Resizable>


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
Allows for `grid` prop to be passed into `<SortablePane />` so it could be passed down to each `<Resizable />` component allowing for panes to 'snap'.
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
dvc

### Testing Done
<!-- How have you confirmed this feature works? -->
Feature sampled locally

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


