### PR TITLE
Mapping keys to refs bug fix

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -182,7 +182,7 @@ class SortablePane extends React.Component<SortablePaneProps, State> {
     const newPanes = this.panes.map((pane, i) => {
       return {
         key: pane.key,
-        ref: panes[this.order.indexOf(i)],
+        ref: panes[this.order[i]],
       };
     });
     this.setState({ panes: newPanes });


### PR DESCRIPTION
Solving this [issue](https://github.com/bokuweb/react-sortable-pane/issues/202)
The problem was a minor mistake during mapping keys and refs to DOM in the ComponentDidMount method.
This PR should fix the issue and, I hope, will not cause new bugs 😁