### PR TITLE
Added ability to specify custom springConfig

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Motion, spring } from 'react-motion';
+import { Motion, spring, SpringHelperConfig } from 'react-motion';
 import { ResizableDirection } from 're-resizable';
 import ResizeObserver from 'resize-observer-polyfill';
 import isEqual from 'lodash.isequal';
@@ -31,13 +31,7 @@ const directionDict: { [key: string]: PaneResizeDirection } = {
 
 const clamp = (n: number, min = n, max = n): number => Math.max(Math.min(n, max), min);
 
-type Spring = {
-  damping?: number;
-  stiffness?: number;
-  precision?: number;
-};
-
-const springConfig: Spring = {
+const defaultSpringConfig: SpringHelperConfig = {
   damping: 30,
   stiffness: 500,
 };
@@ -93,6 +87,7 @@ export type SortablePaneProps = {
   dragHandleClassName?: string;
   defaultOrder?: string[];
   order?: string[];
+  springConfig?: SpringHelperConfig,
   children: React.ReactElement<PaneProps>[];
 };
 
@@ -127,6 +122,7 @@ class SortablePane extends React.Component<SortablePaneProps, State> {
     className: '',
     disableEffect: false,
     isSortable: true,
+    springConfig: defaultSpringConfig
   };
 
   constructor(props: SortablePaneProps) {
@@ -516,7 +512,7 @@ class SortablePane extends React.Component<SortablePaneProps, State> {
 
   renderPanes() {
     const { mouse, isPressed, lastPressed, isResizing } = this.state;
-    const { disableEffect, isSortable } = this.props;
+    const { disableEffect, isSortable, springConfig } = this.props;
     const children = this.props.children || [];
     return children.map((child, i) => {
       const pos = this.props.order

--- a/src/react-sortable-pane.es5.js.flow
+++ b/src/react-sortable-pane.es5.js.flow
@@ -25,6 +25,7 @@ export type SortablePaneProps = {
   dragHandleClassName?: string,
   defaultOrder?: string[],
   order?: string[],
+  springConfig?: { stiffness?: number, damping?: number, precision?: number }
   children: Pane[],
 };
 
@@ -44,6 +45,7 @@ class SortablePane extends React.Component<SortablePaneProps> {
     onOrderChange: () => {},
     className: '',
     disableEffect: false,
+    springConfig: { damping: 30, stiffness: 500 },
     isSortable: true,
   };
 }


### PR DESCRIPTION
### Proposed solution
Now it's possible to customize the animation in your own way by passing springConfig prop into SortablePane component. Hardcoded config became defaultProps.


### Tradeoffs
The name of the prop might be too generic. Perhaps in the future we would like to pass different config for scale and shadow properties. However, in my opinion it’s premature to set this expansion point right  now.


### Testing Done
I have tested my changes via yarn link in the local project. 
Is there a need for additional tests (e.g. cypress)?

